### PR TITLE
Scrollable viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Much of this is what could be called a pre-assembler.  That is I have written my
 To convert the .rbs file to an assembly file run the command
 
 ````
-ruby dcpu.rb <dcpu.rbs > dcpu.asm
+ruby dcpu.rb <dcpu.rbs > dcpu.dasm16
 ````

--- a/dcpu.rbs
+++ b/dcpu.rbs
@@ -1,14 +1,17 @@
-HW_KEYBOARD = 1
 KBD_BS = 0x10
 
 set pc, :_start
 # z in the forth next instruction pointer
 # i is the next forth instruction pointer
 # j is the forth return stack pointer
+# all routines must preserve the above values
 
 # Display
 BUFR_SCREEN = 0x8000
 defvar 'HW_SCREEN', 0xFFFF
+
+# Keyboard
+defvar 'HW_KEYBOARD', 0xFFFF
 
 label :DOCOL_CODE
 begin
@@ -827,7 +830,7 @@ end
 # munges c, x
 defsubr :_key do
   set a, 1
-  hwi HW_KEYBOARD
+  hwi [var_HW_KEYBOARD]
   set a, c
 end
 
@@ -988,8 +991,19 @@ end
 
 
 defsubr :_setup_kbd do
+label :_setup_kbd_loop
+  add [var_HW_KEYBOARD], 1
+  hwq [var_HW_KEYBOARD]
+  ife a, 0x7406
+  ife b, 0x30cf
+  ife c, 0x0001
+#    ife x, 0xXXXX  ; generic
+#    ife y, 0xXXXX
+    set pc, _setup_kbd_hdw_found
+  set pc, _setup_kbd_loop
+label :_setup_kbd_hdw_found
   set a, 0
-  hwi HW_KEYBOARD
+  hwi [var_HW_KEYBOARD]
 end
 
 defsubr :_setup_screen do

--- a/dcpu.rbs
+++ b/dcpu.rbs
@@ -814,31 +814,13 @@ defsubr :_read_line do
   jsr :_key                     # get (non-blocking) character
   ife a, 0
     set pc, :_read_line_next    # if none loop
-  ife a, KBD_UP                 # scroll up
-    set pc, :_read_line_scrollup
-  ife a, KBD_DOWN               # scroll up
-    set pc, :_read_line_scrolldown
   jsr :_echo                    # echo it to the screen
-  set c, 0
-  jsr :_screen_offset           # set the screen offset to 0 so we can see the character
   ifn a, KBD_BS                 # if it is a backspace
     set pc, :_read_line_skip_bs
   ife b, 0                      # and we have some characters in the buffer
     set pc, :_read_line_next
   sub b, 1                      # backup the buffer
   sub y, 1
-  set pc, :_read_line_next
-
-  label :_read_line_scrollup
-  set c, [var_SCREEN_OFFSET]
-  add c, 1
-  jsr :_screen_offset
-  set pc, :_read_line_next
-
-  label :_read_line_scrolldown
-  set c, [var_SCREEN_OFFSET]
-  sub c, 1
-  jsr :_screen_offset
   set pc, :_read_line_next
 
   label :_read_line_skip_bs
@@ -850,11 +832,32 @@ defsubr :_read_line do
 end
 
 # 0 or <next-char>  => a
+# handles viewport scrolling
 # munges c, x
 defsubr :_key do
+label :_key_start
   set a, 1
   hwi [var_HW_KEYBOARD]
   set a, c
+  ife a, KBD_UP                 # scroll up
+    set pc, :_key_scrollup
+  ife a, KBD_DOWN               # scroll down
+    set pc, :_key_scrolldown
+  set pc, :_key_end
+
+  label :_key_scrollup
+  set x, [var_SCREEN_OFFSET]
+  add x, 1
+  jsr :_screen_offset
+  set pc, :_key_start
+
+  label :_key_scrolldown
+  set x, [var_SCREEN_OFFSET]
+  sub x, 1
+  jsr :_screen_offset
+  set pc, :_key_start
+
+label :_key_end
 end
 
 defsubr _upcase do
@@ -932,7 +935,9 @@ defsubr '_echo' do
   jsr :_scroll
   and_ a, 0x7f
   set [var_NEXTOUT], x
-  set [x], 0x809c     # cursor character
+  set [x], 0x809c               # cursor character
+  set x, 0
+  jsr :_screen_offset           # set the screen offset to 0 so we can see the character
 end
 
 defsubr '_scroll' do
@@ -951,19 +956,19 @@ defsubr '_scroll' do
   set x, SCREEN_BUFR + (32 * (SCREEN_LINES - 1))
 end
 
-# c: offset (0 to display_lines-12)
+# x: offset (0 to display_lines-12)
 # changes the offset of the viewport in the buffer
 # modifies hardware, if needed
 defsubr '_screen_offset' do
-  ife c, [var_SCREEN_OFFSET]
+  ife x, [var_SCREEN_OFFSET]
     set pc, :_screen_offset_end   # fast return as this is called per keystroke
-  ifg c, SCREEN_LINES - 12        # don't display past the buffer
+  ifg x, SCREEN_LINES - 12        # don't display past the buffer
     set pc, _screen_offset_end
   set push, b
   # set beginning of viewport (video-mapped RAM) to SCREEN_BUFR + (32 * (SCREEN_LINES - 12 - offset))
-  set [var_SCREEN_OFFSET], c
+  set [var_SCREEN_OFFSET], x
   set b, SCREEN_LINES - 12
-  sub b, c                # desired offset
+  sub b, x                # desired offset
   shl b, 5                # multiply by 32 (words per line)
   add b, SCREEN_BUFR
   set push, a

--- a/dcpu.rbs
+++ b/dcpu.rbs
@@ -1,4 +1,3 @@
-KBD_BS = 0x10
 
 set pc, :_start
 # z in the forth next instruction pointer
@@ -7,10 +6,15 @@ set pc, :_start
 # all routines must preserve the above values
 
 # Display
-BUFR_SCREEN = 0x8000
+SCREEN_BUFR = 0x8000
+SCREEN_LINES = 24
 defvar 'HW_SCREEN', 0xFFFF
+defvar 'SCREEN_OFFSET', 0
 
 # Keyboard
+KBD_BS = 0x10
+KBD_UP = 0x7D
+KBD_DOWN = 0x7B
 defvar 'HW_KEYBOARD', 0xFFFF
 
 label :DOCOL_CODE
@@ -805,17 +809,36 @@ end
 # munges a, b, c, x, y
 defsubr :_read_line do
   set b, 0                      # set the number of characters read into buffer
+
   label :_read_line_next
   jsr :_key                     # get (non-blocking) character
   ife a, 0
-  set pc, :_read_line_next      # if none loop
+    set pc, :_read_line_next    # if none loop
+  ife a, KBD_UP                 # scroll up
+    set pc, :_read_line_scrollup
+  ife a, KBD_DOWN               # scroll up
+    set pc, :_read_line_scrolldown
   jsr :_echo                    # echo it to the screen
+  set c, 0
+  jsr :_screen_offset           # set the screen offset to 0 so we can see the character
   ifn a, KBD_BS                 # if it is a backspace
-  set pc, :_read_line_skip_bs
+    set pc, :_read_line_skip_bs
   ife b, 0                      # and we have some characters in the buffer
-  set pc, :_read_line_next
+    set pc, :_read_line_next
   sub b, 1                      # backup the buffer
   sub y, 1
+  set pc, :_read_line_next
+
+  label :_read_line_scrollup
+  set c, [var_SCREEN_OFFSET]
+  add c, 1
+  jsr :_screen_offset
+  set pc, :_read_line_next
+
+  label :_read_line_scrolldown
+  set c, [var_SCREEN_OFFSET]
+  sub c, 1
+  jsr :_screen_offset
   set pc, :_read_line_next
 
   label :_read_line_skip_bs
@@ -905,31 +928,54 @@ defsubr '_echo' do
   set [x], a
   add x, 1
   label :_echo_finish
-  ifg x, 0x817f
+  ifg x, SCREEN_BUFR + (32 * SCREEN_LINES) - 1
   jsr :_scroll
   and_ a, 0x7f
   set [var_NEXTOUT], x
-  set [x], 0x809c
+  set [x], 0x809c     # cursor character
 end
 
 defsubr '_scroll' do
-  set x, BUFR_SCREEN
+  set x, SCREEN_BUFR
   label :_scroll_loop1
   set [x], [x + 32]
   add x, 1
-  ifg 0x8160, x
-  set pc, :_scroll_loop1
+  ifg SCREEN_BUFR + (32 * (SCREEN_LINES - 1)), x
+    set pc, :_scroll_loop1
 
   label :_scroll_loop2
   set [x], 0
   add x, 1
-  ifg 0x8180, x
-  set pc, :_scroll_loop2
-  set x, 0x8160
+  ifg SCREEN_BUFR + (32 * SCREEN_LINES), x
+    set pc, :_scroll_loop2
+  set x, SCREEN_BUFR + (32 * (SCREEN_LINES - 1))
+end
+
+# c: offset (0 to display_lines-12)
+# changes the offset of the viewport in the buffer
+# modifies hardware, if needed
+defsubr '_screen_offset' do
+  ife c, [var_SCREEN_OFFSET]
+    set pc, :_screen_offset_end   # fast return as this is called per keystroke
+  ifg c, SCREEN_LINES - 12        # don't display past the buffer
+    set pc, _screen_offset_end
+  set push, b
+  # set beginning of viewport (video-mapped RAM) to SCREEN_BUFR + (32 * (SCREEN_LINES - 12 - offset))
+  set [var_SCREEN_OFFSET], c
+  set b, SCREEN_LINES - 12
+  sub b, c                # desired offset
+  shl b, 5                # multiply by 32 (words per line)
+  add b, SCREEN_BUFR
+  set push, a
+  set a, 0                # map screen
+  hwi [var_HW_SCREEN]
+  set a, pop
+  set b, pop
+label :_screen_offset_end
 end
 
 defvar 'nextchar', 0x9000
-defvar 'nextout', BUFR_SCREEN
+defvar 'nextout', SCREEN_BUFR + (32 * (SCREEN_LINES - 12)) # cursor position in video RAM
 
 defvar 'getc_buffer_limit', :text_end
 defvar 'getc_buffer_nextchar', :text_start


### PR DESCRIPTION
Scrolling screen viewport works great! Use '{' and '}' for now or set the constants to something else.

Sorry for all the commits -- the last one was intentional. After moving viewport handing to _key and _echo, I saw one weird error in my testing that I was never able to repro. I suspect someone may be relying on a register that I had to use. (It was marked as 'munged' but wasn't actually, until I munged it.)
